### PR TITLE
Update types file to use new default export syntax

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,4 +15,4 @@ console.log(os.tmpdir());
 */
 declare const tempDirectory: string;
 
-export = tempDirectory;
+export default tempDirectory;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
 import {expectType} from 'tsd';
-import tempDirectory = require('.');
+import tempDirectory from '.';
 
 expectType<string>(tempDirectory);


### PR DESCRIPTION
Hi,

Using the old syntax for default export makes an error with ESLint and the import plugin. More details: benmosher/eslint-plugin-import#558 (comment)

This patch uses the new syntax.